### PR TITLE
Remove request rate limiting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,6 @@ const adminPanelRoutes = require('./routes/admin-panel');
 
 // Importar configuración de trabajos cron
 const { initCronJobs } = require('./jobs/cron');
-// Importar middlewares de optimización
-const { requestLogger, concurrencyLimiter, earlyRateLimiter } = require('./middleware/request-limiter');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -34,9 +32,6 @@ app.use(express.json());
 // Configurar trust proxy para obtener IP real
 app.set('trust proxy', true);
 
-// Rate limiting temprano (antes de autenticación)
-app.use(earlyRateLimiter);
-
 // Middleware de logging básico solo para peticiones importantes
 app.use((req, res, next) => {
     // Solo loggear peticiones que no sean GET o que tengan problemas
@@ -46,9 +41,6 @@ app.use((req, res, next) => {
     }
     next();
 });
-
-// El requestLogger se aplicará en las rutas específicas después de la autenticación
-app.use(concurrencyLimiter);
 
 // Configurar almacenamiento de archivos
 const storage = multer.diskStorage({

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -17,21 +17,6 @@ const authenticateJWT = async (req, res, next) => {
     }
 
     const token = authHeader.split(' ')[1];
-    const clientIP = req.ip || req.connection.remoteAddress;
-    
-    // Rate limiting DESACTIVADO para desarrollo - Solo para casos extremos
-    const maxRequests = 1000; // Límite muy alto, solo para casos extremos
-    
-    // Solo activar rate limiting en casos extremos
-    if (!authCache.checkRateLimit(`auth:${clientIP}`, maxRequests)) {
-        console.log(`Rate limit extremo excedido para IP: ${clientIP}`);
-        return res.status(429).json({
-            error: 'Too many requests',
-            message: 'La aplicación está muy ocupada. Por favor espere un momento.',
-            retryAfter: 1,
-            suggestion: 'Evite refrescar la página repetidamente'
-        });
-    }
 
     try {
         // Verificar cache de token primero

--- a/src/middleware/request-limiter.js
+++ b/src/middleware/request-limiter.js
@@ -1,49 +1,10 @@
-const authCache = require('../utils/auth-cache');
-
 /**
  * Middleware para prevenir peticiones duplicadas y agrupadas
+ *
+ * Actualmente no aplica ninguna restricción y simplemente continúa con la petición.
  */
-const requestLimiter = (options = {}) => {
-    const {
-        windowMs = 1000, // 1 segundo
-        maxDuplicates = 3, // máximo 3 peticiones idénticas en la ventana de tiempo
-        skipSuccessfulGET = true // skip rate limit for successful GET requests
-    } = options;
-
-    return (req, res, next) => {
-        // Crear una key única para la petición basada en método, URL y usuario
-        const userId = req.user?.id || 'anonymous';
-        const requestKey = `${req.method}:${req.path}:${userId}`;
-        const clientIP = req.ip || req.connection.remoteAddress;
-        
-        // Para peticiones de autenticación, usar rate limiting más estricto
-        if (req.path.includes('/auth') && req.method === 'GET') {
-            if (!authCache.checkRateLimit(`duplicate:${requestKey}`, maxDuplicates)) {
-                console.log(`Duplicate request blocked: ${requestKey} from IP: ${clientIP}`);
-                return res.status(429).json({
-                    error: 'Duplicate request',
-                    message: 'Petición duplicada detectada. Evite hacer múltiples peticiones simultáneas.',
-                    retryAfter: Math.ceil(windowMs / 1000)
-                });
-            }
-        }
-
-        // Para peticiones de estadísticas, ser extremadamente permisivo (operación compleja)
-        if (req.path.includes('/stats') || req.path.includes('/updated-stats') || req.path.includes('/estadisticas/')) {
-            if (!authCache.checkRateLimit(`stats:${requestKey}`, 60)) { // Aumentado de 30 a 60
-                console.log(`Stats request rate limited: ${requestKey} from IP: ${clientIP}`);
-                return res.status(429).json({
-                    error: 'Stats rate limit',
-                    message: 'Actualizando datos... Un momento por favor.',
-                    retryAfter: 2, // Reducido de 5 a 2 segundos
-                    isRetryable: true,
-                    isStatsRequest: true
-                });
-            }
-        }
-
-        next();
-    };
+const requestLimiter = () => {
+    return (req, res, next) => next();
 };
 
 /**
@@ -65,62 +26,21 @@ const requestLogger = (req, res, next) => {
 
 /**
  * Middleware de rate limiting temprano (antes de autenticación)
+ *
+ * Desactivado: no impone ningún límite de peticiones.
  */
-const earlyRateLimiter = (req, res, next) => {
-    const clientIP = req.ip || req.connection.remoteAddress;
-    
-    // DESACTIVADO TEMPORALMENTE - Rate limiting muy permisivo para desarrollo
-    // Solo activar en casos extremos (más de 1000 peticiones por minuto)
-    if (!authCache.checkRateLimit(`early:${clientIP}`, 1000)) { 
-        console.log(`🚫 Rate limit extremo excedido: IP ${clientIP}`);
-        return res.status(429).json({
-            error: 'Too many requests',
-            message: 'Demasiadas peticiones detectadas.',
-            retryAfter: 1,
-            isRetryable: true
-        });
-    }
-    
-    next();
-};
+const earlyRateLimiter = (req, res, next) => next();
 
 /**
  * Middleware para manejar peticiones simultáneas
+ *
+ * Desactivado: permite todas las peticiones sin restricciones.
  */
-const concurrencyLimiter = (req, res, next) => {
-    const userId = req.user?.id;
-    if (!userId) return next();
-
-    const concurrentKey = `concurrent:${userId}`;
-    const currentCount = authCache.requestCounts.get(concurrentKey) || 0;
-    
-    // Máximo 5 peticiones simultáneas por usuario
-    if (currentCount >= 5) {
-        console.log(`Concurrency limit exceeded for user: ${userId}`);
-        return res.status(429).json({
-            error: 'Too many concurrent requests',
-            message: 'Demasiadas peticiones simultáneas. Espere a que terminen las anteriores.',
-            retryAfter: 2
-        });
-    }
-
-    // Incrementar contador
-    authCache.requestCounts.set(concurrentKey, currentCount + 1, 10); // TTL de 10 segundos
-    
-    // Decrementar al terminar la petición
-    res.on('finish', () => {
-        const newCount = authCache.requestCounts.get(concurrentKey) || 0;
-        if (newCount > 0) {
-            authCache.requestCounts.set(concurrentKey, newCount - 1, 10);
-        }
-    });
-
-    next();
-};
+const concurrencyLimiter = (req, res, next) => next();
 
 module.exports = {
     requestLimiter,
     requestLogger,
     concurrencyLimiter,
     earlyRateLimiter
-}; 
+};


### PR DESCRIPTION
## Summary
- disable request limiter, early rate limiter, and concurrency limiter middlewares so they simply pass through
- drop rate limiting checks from authentication middleware to avoid IP blocking
- remove global rate limiter usage from server setup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4ef12783c8332978b0be085d24290